### PR TITLE
#2470 インストール・アンインストール済みのドライバに対してのエラー出す箇所の1つを削除

### DIFF
--- a/ita_root/ita_api_admin/controllers/organization_create_controller.py
+++ b/ita_root/ita_api_admin/controllers/organization_create_controller.py
@@ -505,12 +505,6 @@ def organization_update(organization_id, body=None):  # noqa: E501
                 # bodyのdriversに指定のドライバ名以外のkeyがある際にエラーとする。
                 if driver_name not in driver_list:
                     return '', "Value of key[drivers] is invalid.", "499-00004", 499
-                # インストール済みのドライバをtrue、インストールしていないドライバをfalseに指定した際にエラーとする。
-                elif driver_name not in no_install_driver and driver_bool is True:
-                    return '', "{} is already installed. ".format(json.dumps(driver_name)), "499-00007", 499
-                elif driver_name in no_install_driver and driver_bool is False:
-                    return '', "{} is already uninstalled.".format(json.dumps(driver_name)), "499-00007", 499
-
         else:
             # body内でdriverが指定されていないためエラーとする。
             return '', "Body paramater 'drivers' is required.", "499-00004", 499


### PR DESCRIPTION
下記処理を削除
・追加するドライバの対象が、no_install_driverに含まれていない（すでにインストール済み）場合は追加対象から除外する
・削除するドライバの対象が、no_install_driverに含まれている場合は削除対象から除外する