### PR TITLE
OASEで一度にルール判定できない #2739

### DIFF
--- a/ita_root/common_libs/oase/manage_events.py
+++ b/ita_root/common_libs/oase/manage_events.py
@@ -188,11 +188,9 @@ class ManageEvents:
 
         # incident_dictに登録されているイベントをfilter_match_listに格納する
         filter_match_list = []
-        for filter_id, id_value in incident_dict.items():
-            if type(id_value) is list:
-                filter_match_list += id_value
-            else:
-                filter_match_list.append(id_value)
+        for filter_id, id_value_list in incident_dict.items():
+            if len(id_value_list) > 0:
+                filter_match_list += id_value_list
 
         for event_id, event in self.labeled_events_dict.items():
             # タイムアウトしたイベントは登録されているのでスキップ

--- a/ita_root/ita_by_oase_conclusion/libs/action.py
+++ b/ita_root/ita_by_oase_conclusion/libs/action.py
@@ -245,7 +245,13 @@ class Action():
             label_key_name = getIDtoLabelName(labelMaster, setting["label_key"])
             # label_valueに変数ブロックが含まれている場合、jinja2テンプレートで値を変換
             template = Template(setting["label_value"])
-            label_value = template.render(A=event_A_labels, B=event_B_labels)
+            try:
+                label_value = template.render(A=event_A_labels, B=event_B_labels)
+            except Exception as e:
+                t = traceback.format_exc()
+                g.applogger.info("[timestamp={}] {}".format(str(get_iso_datetime()), arrange_stacktrace_format(t)))
+
+                label_value = "CONCLUSION LABELS jinja2TEMPLATE ERROR ({})".format(e)
 
             ab_merged_labels[label_key_name] = label_value
             setting_only_labels[label_key_name] = label_value


### PR DESCRIPTION
IncidentDictは
・FilterIdに対して、単独イベントであっても配列型で保存する
・フィルターの検索方法がユニークで複数イベントが合致してしまった場合は
FilterIdに対して空配列を保存することで、後から追加される可能性のあるイベントを未知に落とすかどうかの判定をできるようにする