### PR TITLE
【パフォーマンス改善】OASE ConclusionのPython処理系をPyPyに変更

### DIFF
--- a/ita_root/ita_by_oase_conclusion/Dockerfile
+++ b/ita_root/ita_by_oase_conclusion/Dockerfile
@@ -33,7 +33,10 @@ ENV EVALUATE_LATENT_INFINITE_LOOP_LIMIT=1000
 # ハングアップ監視用ファイル
 ENV FILE_PATH_LIVENESS=/tmp/liveness
 
+ENV PATH /opt/pypy/bin:$PATH
+
 RUN --mount=type=secret,id=host_certificate_file,dst=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    set -eux; \
     dnf install -y \
     gcc \
     openssh-clients \
@@ -41,12 +44,68 @@ RUN --mount=type=secret,id=host_certificate_file,dst=/etc/pki/ca-trust/extracted
     wget \
     zip \
     unzip \
+    bzip2 \
+    jq \
     python3.11 \
     python3.11-devel \
     python3.11-pip \
-&&  alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1000000 \
 &&  alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 100 \
-&&  alternatives --set python3 /usr/bin/python3.11 \
+&&  alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1000000 
+# &&  alternatives --set python3 /usr/bin/python3.11 \
+#\
+# start pypy install  
+RUN set -eux; \
+    python_version="3.11" \
+&&  pypy_version="7.3" \
+&&  platform="linux" \
+&&  unameArch="$(uname -m)" \
+&&  case "$unameArch" in \
+        'x86_64' | 'x64' | 'amd64') arch='x64'; ;; \
+        'aarch64') arch='aarch64'; ;; \
+        'i686' | 'i386' | 'x86') arch='i686'; ;; \
+        *) echo >&2 "error: current architecture ($unameArch) does not have a corresponding PyPy binary release"; exit 1 ;; \
+    esac \
+&&  pypy_download_url=$( \
+        wget --progress=dot:giga -O- https://downloads.python.org/pypy/versions.json \
+        | jq \
+            --arg pypy_version "$pypy_version" \
+            --arg python_version "$python_version" \
+            --arg platform "$platform" \
+            --arg arch "$arch" \
+            -r \
+            ''' \
+            map( \
+                select( \
+                    .stable \
+                    and (.pypy_version | startswith($ARGS.named.pypy_version)) \
+                    and (.python_version | startswith($ARGS.named.python_version)) \
+                ) \
+            ) \
+            | sort_by(-(.pypy_version | ltrimstr($ARGS.named.pypy_version + ".") | tonumber)) \
+            | first.files[] \
+            | select(.platform == $ARGS.named.platform and .arch == $ARGS.named.arch).download_url \
+            ''' \
+    ) \
+&&  wget --progress=dot:giga -O pypy.tar.bz2 "${pypy_download_url}" \
+&&  mkdir /opt/pypy \
+&&  tar -xjC /opt/pypy --strip-components=1 -f pypy.tar.bz2 \
+&&  find /opt/pypy/lib* -depth -type d -a \( -name test -o -name tests \) -exec rm -rf '{}' + \
+&&  rm pypy.tar.bz2 \
+&&  dnf remove -y bzip2 jq \
+&&  ln -sv '/opt/pypy/bin/pypy3' /usr/local/bin/ \
+&&  alternatives --install /usr/bin/python3 python3 /opt/pypy/bin/python3.11 50 \
+&&  alternatives --set python3 /opt/pypy/bin/python3.11 \
+&&  alternatives --install /usr/bin/pip3.11 pip3.11 /opt/pypy/bin/pip3.11 50 \
+&&  alternatives --set pip3.11 /opt/pypy/bin/pip3.11 \
+&&  python3 -m ensurepip \
+&&  pip3.11 install --disable-pip-version-check --no-cache-dir --no-compile 'wheel<0.46' \
+&& 	find /opt/pypy -depth \
+		\( \
+			\( -type d -a \( -name test -o -name tests \) \) \
+			-o \
+			\( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+		\) -exec rm -rf '{}' + \
+# end pypy install
 &&  pip3.11 install poetry==1.8.4 \
 &&  poetry config virtualenvs.create false \
 &&  groupadd $GROUPNAME \
@@ -57,10 +116,8 @@ WORKDIR $APP_PATH
 COPY ./ita_root/ita_by_oase_conclusion/pyproject.toml ./ita_root/ita_by_oase_conclusion/poetry.lock $APP_PATH/
 
 RUN --mount=type=secret,id=host_certificate_file,dst=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-    poetry install --only first_install
-
-RUN --mount=type=secret,id=host_certificate_file,dst=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-    poetry install --without develop_build
+    poetry install --only first_install \
+&&  poetry install --without develop_build
 
 #
 # Build for development


### PR DESCRIPTION
Dockerfileを変更しOASE ConclusionのPython処理系をPyPyに変更
PyPyはPython3.11.xを実装した7.3.xをダウンロード・インストールする
インストール後にDocker公式イメージの構築内容に沿って不要ファイルの削除を実行
以下確認済み
- python3コマンドでPyPyが動作すること
- backyardが動作すること
- PythonデバッガーがPyPyで動作すること
  - alternativesの働きで特に調整の必要はありませんでした