### PR TITLE
#2822 OASE ルール判定の処理のパフォーマンス改善 / プロセス異常時処理・ログメッセージ修正

### DIFF
--- a/ita_root/ita_by_oase_conclusion/backyard_main.py
+++ b/ita_root/ita_by_oase_conclusion/backyard_main.py
@@ -100,11 +100,11 @@ def backyard_main(organization_id, workspace_id):
         tmp_msg = g.appmsg.get_log_message("BKY-90003", [])
         g.applogger.info(addline_msg('{}'.format(tmp_msg)))  # noqa: F405
     finally:
+        WriterProcessManager.finish_workspace_processing()  # 一応、Finaryでも入れておく（例外発生時）
+        NotificationProcessManager.finish_workspace_processing()
         wsDb.db_transaction_end(False)
         wsDb.db_disconnect()
         wsMongo.disconnect()
-
-    NotificationProcessManager.finish_workspace_processing()
 
     # メイン処理終了
     tmp_msg = g.appmsg.get_log_message("BKY-90000", ['Ended'])

--- a/ita_root/ita_by_oase_conclusion/backyard_main.py
+++ b/ita_root/ita_by_oase_conclusion/backyard_main.py
@@ -450,12 +450,10 @@ def JudgeMain(wsDb, judgeTime, EventObj, actionObj):
 
 
 def on_start_process(*args, **kwargs):
-    g.applogger.info("CALL on_start_process")
     NotificationProcessManager.start_process()
     WriterProcessManager.start_process()
 
 
 def on_exit_process(*args, **kwargs):
-    g.applogger.info("CALL on_exit_process")
     NotificationProcessManager.stop_process()
     WriterProcessManager.stop_process()

--- a/ita_root/ita_by_oase_conclusion/libs/notification_process.py
+++ b/ita_root/ita_by_oase_conclusion/libs/notification_process.py
@@ -245,5 +245,5 @@ class NotificationProcess():
                     break
 
             except Exception as e:
-                g.applogger.info(f"NotificationProcess: error occurred. {e}")
-                g.applogger.info("[timestamp={}] {}".format(str(get_iso_datetime()), arrange_stacktrace_format(traceback.format_exc())))
+                g.applogger.error(f"NotificationProcess: error occurred. {e}")
+                g.applogger.error("[timestamp={}] {}".format(str(get_iso_datetime()), arrange_stacktrace_format(traceback.format_exc())))

--- a/ita_root/ita_by_oase_conclusion/poetry.lock
+++ b/ita_root/ita_by_oase_conclusion/poetry.lock
@@ -561,26 +561,25 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "psutil"
-version = "7.0.0"
-description = "Cross-platform lib for process and system monitoring in Python.  NOTE: the syntax of this script MUST be kept compatible with Python 2.7."
+version = "7.1.0"
+description = "Cross-platform lib for process and system monitoring."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "psutil-7.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:101d71dc322e3cffd7cea0650b09b3d08b8e7c4109dd6809fe452dfd00e58b25"},
-    {file = "psutil-7.0.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:39db632f6bb862eeccf56660871433e111b6ea58f2caea825571951d4b6aa3da"},
-    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fcee592b4c6f146991ca55919ea3d1f8926497a713ed7faaf8225e174581e91"},
-    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b1388a4f6875d7e2aff5c4ca1cc16c545ed41dd8bb596cefea80111db353a34"},
-    {file = "psutil-7.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5f098451abc2828f7dc6b58d44b532b22f2088f4999a937557b603ce72b1993"},
-    {file = "psutil-7.0.0-cp36-cp36m-win32.whl", hash = "sha256:84df4eb63e16849689f76b1ffcb36db7b8de703d1bc1fe41773db487621b6c17"},
-    {file = "psutil-7.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:1e744154a6580bc968a0195fd25e80432d3afec619daf145b9e5ba16cc1d688e"},
-    {file = "psutil-7.0.0-cp37-abi3-win32.whl", hash = "sha256:ba3fcef7523064a6c9da440fc4d6bd07da93ac726b5733c29027d7dc95b39d99"},
-    {file = "psutil-7.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553"},
-    {file = "psutil-7.0.0.tar.gz", hash = "sha256:7be9c3eba38beccb6495ea33afd982a44074b78f28c434a1f51cc07fd315c456"},
+    {file = "psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13"},
+    {file = "psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5"},
+    {file = "psutil-7.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22e4454970b32472ce7deaa45d045b34d3648ce478e26a04c7e858a0a6e75ff3"},
+    {file = "psutil-7.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c70e113920d51e89f212dd7be06219a9b88014e63a4cec69b684c327bc474e3"},
+    {file = "psutil-7.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d4a113425c037300de3ac8b331637293da9be9713855c4fc9d2d97436d7259d"},
+    {file = "psutil-7.1.0-cp37-abi3-win32.whl", hash = "sha256:09ad740870c8d219ed8daae0ad3b726d3bf9a028a198e7f3080f6a1888b99bca"},
+    {file = "psutil-7.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:57f5e987c36d3146c0dd2528cd42151cf96cd359b9d67cfff836995cc5df9a3d"},
+    {file = "psutil-7.1.0-cp37-abi3-win_arm64.whl", hash = "sha256:6937cb68133e7c97b6cc9649a570c9a18ba0efebed46d8c5dae4c07fa1b67a07"},
+    {file = "psutil-7.1.0.tar.gz", hash = "sha256:655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2"},
 ]
 
 [package.extras]
-dev = ["abi3audit", "black (==24.10.0)", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest", "pytest-cov", "pytest-xdist", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel"]
-test = ["pytest", "pytest-xdist", "setuptools"]
+dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pyreadline", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-xdist", "pywin32", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel", "wheel", "wmi"]
+test = ["pytest", "pytest-instafail", "pytest-subtests", "pytest-xdist", "pywin32", "setuptools", "wheel", "wmi"]
 
 [[package]]
 name = "pycodestyle"
@@ -1037,4 +1036,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5a4e59a58a1afa12db07948dbafd3f2220d7f68f0ea23b8e07f42dbfb798d713"
+content-hash = "58c7b40c10d34c24523b82cdf65a208684833a3619eadbbd777cbaeafa6ca160"

--- a/ita_root/ita_by_oase_conclusion/pyproject.toml
+++ b/ita_root/ita_by_oase_conclusion/pyproject.toml
@@ -18,6 +18,7 @@ chardet = ">=0.0.0"
 pycryptodome = ">=0.0.0"
 pymongo = ">=0.0.0"
 jsonlines = ">=0.0.0"
+psutil = ">=0.0.0"
 
 
 [tool.poetry.group.first_install.dependencies]

--- a/ita_root/messages/LOG.json
+++ b/ita_root/messages/LOG.json
@@ -1366,6 +1366,13 @@
     "MSG-160001": "Both Labels and Expression must be entered to specify Condition.",
     "MSG-160002": "Event Source and Condition Label are not linked in the Labeling menu. (Event Collection Settings Name: {}, Label: {})",
     "MSG-160003": "Condition Label is not linked to any specified Event Source in the Labeling menu. (Label: {})",
+    "MSG-170001": "Event types cannot be changed for Notification Templates ID from 1 to 4.",
+    "MSG-170002": "Notification Destination cannot be changed for Notification Templates ID from 1 to 4.",
+    "MSG-170003": "If the Notification Template ID is other than 1 to 4, you must be entered Notification Destination.",
+    "MSG-170004": "Do not overlap Notification Destinations within the event type for Notification Templates ID from 1 to 4.(Duplicate target: {}, Duplicate Notification Destination: {})",
+    "MSG-170005": "Cannot be deleted for the Notification Templates ID from 1 to 4.",
+    "MSG-170006": "Cannot be discarded for the Notification Templates ID from 1 to 4.",
+    "MSG-170007": "Cannot be Restored for the Notification Templates ID from 1 to 4.",
     "BKY-00001": "[backyard]main process is started",
     "BKY-00002": "[backyard]main process is finished",
     "BKY-00003": "[backyard]main process is finished with error",
@@ -1729,5 +1736,11 @@
     "BKY-90073": "calling 'ConductorExecute'.(action_log_id={})",
     "BKY-90074": "calling 'apply API'.(action_log_id={})",
     "BKY-90075": "Cannnot execute the Action because {} is invalid.(action_log_id={})",
-    "BKY-90076": "Failrue to call 'apply API'.(action_log_id={}, error = {})"
+    "BKY-90076": "Failrue to call 'apply API'.(action_log_id={}, error = {})",
+    "BKY-90077": "SubProcess({}) : {}",
+    "BKY-90078": "Terminate SubProcess({}) as there is no parent process",
+    "BKY-90079": "Change the target workspace of a SubProcess({})",
+    "BKY-90080": "SubProcess({}) processing target workspace processing completed",
+    "BKY-90081": "An error occurred in the SubProcess({}) : {}",
+    "BKY-90082": "MongoBufferedWriter: bulk_write {} records"
 }


### PR DESCRIPTION
- 子プロセスが異常終了していたら、即時に処理中Workspaceの処理を中断する
- Workspaceの処理開始時に子プロセスが存在していない場合、子プロセスを再起動する
- メインプロセスが異常終了した時、子プロセスも終了する
- 通知プロセスもWorkspace処理完了時に全てバッファをFlush済みになるまでWaitする
- ログメッセージ修正