### PR TITLE
OASE Conclusionのグルーピング対象期間対応 (Issue #2901)

### DIFF
--- a/ita_root/ita_by_oase_conclusion/tests/filter.py
+++ b/ita_root/ita_by_oase_conclusion/tests/filter.py
@@ -71,6 +71,21 @@ f_a3_no_period_extension = create_filter_row(
     p_group_label_names,
 )
 "Fillter F_A3_no_period_extension定義"
+"Fillter F_A3_fixed_period定義 ～"
+p_search_condition_id = oaseConst.DF_SEARCH_CONDITION_GROUPING_NO_PERIOD_EXTENSION
+p_group_condition_id = oaseConst.DF_GROUP_CONDITION_ID_TARGET
+p_group_label_names = "_exastro_host,severity,service,status,severity".split(",")
+p_group_period = 5
+p_search_conditions = []
+p_search_conditions.append(("node", oaseConst.DF_TEST_NE, "VALUE"))
+f_a3_fixed_period = create_filter_row(
+    p_search_condition_id,
+    (p_search_conditions if len(p_search_conditions) > 0 else None),
+    p_group_condition_id,
+    p_group_label_names,
+    p_group_period
+)
+"Fillter F_A3_fixed_period定義"
 "Fillter F_A4定義 ～"
 p_search_condition_id = oaseConst.DF_SEARCH_CONDITION_GROUPING
 p_group_condition_id = oaseConst.DF_GROUP_CONDITION_ID_NOT_TARGET

--- a/ita_root/ita_by_oase_conclusion/tests/test_pattern_001_009.py
+++ b/ita_root/ita_by_oase_conclusion/tests/test_pattern_001_009.py
@@ -233,6 +233,60 @@ def test_pattern_003_no_period_extension(
     assert_expected_pattern_results(ws_db, test_events, expected)
 
 
+def test_pattern_003_fixed_period(
+    patch_global_g,
+    patch_notification_and_writer,
+    patch_common_functions,
+    patch_action_using_modules,
+    monkeypatch,
+    patch_database_connections,
+    patch_datetime,
+):
+    """「対象とする」のグルーピング（期間延長なし）/グルーピング対象期間 - グルーピング対象期間でグループが分かれるケースを確認"""
+    g = patch_global_g
+
+    ws_db, mock_mongo = patch_database_connections
+    mock_datetime = patch_datetime
+
+    # イベント
+    test_events = create_events(
+        [f"e{n:03}" for n in itertools.chain(range(1, 14 + 1), [999])], "p3-fp"
+    )
+
+    # ルール
+    r1 = create_rule_row(
+        1,
+        "r1",
+        filter.f_a3_fixed_period,
+        conclusion_label_settings=[["node", "VALUE"]]
+    )
+
+    # 必要なテーブルデータを設定
+    filters = [
+        filter.f_a3_fixed_period,
+    ]
+    rules = [
+        r1,
+    ]
+    run_test_pattern(
+        g, ws_db, mock_mongo, mock_datetime, test_events, filters, rules
+    )
+
+    expected = [
+        ("r1", ["e001", "e002"], None),
+        ("r1", ["e003"], None),
+        ("r1", ["e004", "e005"], None),
+        ("r1", ["e006", "e007"], None),
+        ("r1", ["e008", "e009"], None),
+        ("r1", ["e010", "e011"], None),
+        ("r1", ["e012", "e013"], None),
+        ("r1", ["e014"], None),
+        ("r1", ["e999"], None),
+    ]
+
+    assert_expected_pattern_results(ws_db, test_events, expected)
+
+
 def test_pattern_004(
     patch_global_g,
     patch_notification_and_writer,


### PR DESCRIPTION
**先頭イベントの`exastro_filter_group`フィールドに`end_time`(グループ終了時間)を追加し、イベントの終了時間と独立して管理させる**  
グループ終了時間は以下のフィルターパターンで設定される
| グルーピング対象期間 | 検索条件                         | グループ終了時間の設定値                                                                                                                                                                                              |
| -------------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| **設定済**           | **グルーピング（期間延長あり）** | **不正条件のため未定義<br>(実動作は「グルーピング（期間延長なし）」と同じになるはず)**                                                                                                                                |
| **設定済**           | **グルーピング（期間延長なし）** | **先頭イベントの取得時間+グルーピング対象期間<br>利用想定はTTLより小さい<br>TTLより大きい場合は想定しない(実動作は、グルーピング対象期間は設定通り動くが、TTLの影響で想定しない分け方になり得るはず)<br> (新規仕様)** |
| 未設定               | グルーピング（期間延長あり）     | グループ内の最大イベント終了時間<br>(動作変更なし)                                                                                                                                                                    |
| 未設定               | グルーピング（期間延長なし）     | 先頭イベントの終了時間<br>(動作変更なし)                                                                                                                                                                              |

fix #2901