### PR TITLE
file_read_retry で不要なINFOログを出力させない

### DIFF
--- a/ita_root/common_libs/common/storage_access.py
+++ b/ita_root/common_libs/common/storage_access.py
@@ -323,7 +323,7 @@ def file_read_retry(func):
                 else:
                     # retry分は、メッセージのみを出力
                     # For retry minutes, only the message is output
-                    g.applogger.info(print_exception_msg(e))
+                    print_exception_msg(e)
 
             if i == max:
                 break

--- a/ita_root/common_libs/common/util.py
+++ b/ita_root/common_libs/common/util.py
@@ -377,7 +377,7 @@ def file_read_retry(func):
                 else:
                     # retry分は、メッセージのみを出力
                     # For retry minutes, only the message is output
-                    logger.info(print_exception_msg(e, logger_class=logger))
+                    print_exception_msg(e, logger_class=logger)
 
             if i == max:
                 break


### PR DESCRIPTION
```
[2030-12-31 23:59:59,999][INFO] [ORGANIZATION_ID:org_id][WORKSPACE_ID:ws_id][USER_ID:20101][EXECUTION_NO=XXX] retry_copy2 failed. src_path=/storage/org_id/ws_id/uploadfiles/20101/ssh_private_key_file/YYY/ZZZ, dest_path=/tmp/org_id/ws_id/uploadfiles/20101/ssh_private_key_file/YYY/ZZZ
[2030-12-31 23:59:59,999][INFO] [ORGANIZATION_ID:org_id][WORKSPACE_ID:ws_id][USER_ID:20101][EXECUTION_NO=XXX] [timestamp=2030-12-31T23:59:59.999Z] exception_msg='[Errno 2] No such file or directory: '/tmp/org_id/ws_id/uploadfiles/20101/ssh_private_key_file/YYY/ZZZ'' (storage_access.py:326)
[2030-12-31 23:59:59,999][INFO] [ORGANIZATION_ID:org_id][WORKSPACE_ID:ws_id][USER_ID:20101][EXECUTION_NO=XXX] None
```
不要なNoneという出力を修正
print_exception_msgの中でINFOログを出力するため不要