### PR TITLE
#2766 ファイル名有の場合のバリデーションチェック分岐の条件式誤りを修正

### DIFF
--- a/ita_root/common_libs/column/file_upload_class.py
+++ b/ita_root/common_libs/column/file_upload_class.py
@@ -80,7 +80,7 @@ class FileUploadColumn(Column):
         # ファイル名正規表現　カンマとダブルクォートとタブとスラッシュと改行以外の文字
         preg_match = r"^[^,\"\t\/\r\n]*$"
 
-        if not val:
+        if val:
 
             # 禁止拡張子
             forbidden_extension_arry = self.objdbca.table_select("T_COMN_SYSTEM_CONFIG", "WHERE CONFIG_ID = %s", bind_value_list=['FORBIDDEN_UPLOAD'])  # noqa:E501

--- a/ita_root/common_libs/common/menu_maintenance_all.py
+++ b/ita_root/common_libs/common/menu_maintenance_all.py
@@ -137,6 +137,14 @@ def create_maintenance_parameters(connexion_request, tmp_path):
                         file_path = os.path.join(tmp_file_path, file_name)
                         file_paths[_list_num][_list_key] = file_path
 
+                        # ファイル名の文字列長チェック（255バイト上限）
+                        if len(file_name.encode('utf-8')) > 255:
+                            msg = g.appmsg.get_api_message("MSG-00008", [255, len(file_name.encode('utf-8'))])
+                            args_dict.setdefault(str(files_count), {check_msg: [msg]})
+                            args = json.dumps(args_dict)
+                            status_code = "499-00201"
+                            raise AppException(status_code, [args], [args])
+
                         # ファイルを保存できる容量があるかどうか確認
                         _file_data.seek(0,2)
                         file_size = _file_data.tell()


### PR DESCRIPTION
ファイル名有の場合に通るべき以下のバリデーションチェックが、条件式（if not val → if val）により
ファイル名無しの場合に動作していたため修正