### PR TITLE
#3051 更新時にイベント収集設定IDのレコードが存在しない場合のチェックを追加 

### DIFF
--- a/ita_root/common_libs/validate/valid_110101.py
+++ b/ita_root/common_libs/validate/valid_110101.py
@@ -144,6 +144,11 @@ def agent_setting_valid(objdbca, objtable, option):
                 "WHERE EVENT_COLLECTION_SETTINGS_ID=%s",
                 [setting_id]
             )
+            # 指定されたイベント収集設定IDのレコードが存在しない場合はバリデエラー
+            if not record:
+                msg.append(g.appmsg.get_api_message("MSG-00007", [setting_id]))
+                retBool = False
+                return retBool, msg, option,
             if connection_method != record[0]["CONNECTION_METHOD_ID"]:
                 if password_entered is False:
                     entry_parameter["password"] = None


### PR DESCRIPTION
Excel一括で更新をかける際に、イベント収集設定IDを存在しないIDにした場合バリデーションエラーをかえすように変更。
＞"対象のレコードが存在しません(対象ID:{})"